### PR TITLE
feat: use cached archive if available, allow skip using --no-cache

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -6,6 +6,7 @@ import (
 )
 
 type Flags struct {
+	NoCache bool
 	Verbose bool
 }
 
@@ -92,6 +93,8 @@ func collectFlags(args []string) Flags {
 
 		if arg == "--verbose" {
 			collected.Verbose = true
+		} else if arg == "--no-cache" {
+			collected.NoCache = true
 		}
 	}
 


### PR DESCRIPTION
Cached archives are reused by default if found when using `v install <version>`. This behaviour can be disabled by using `--no-cache`, which always force-downloads a new archive from remote.