### PR TITLE
fix: shim should use v executable from $PATH

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -22,7 +22,7 @@ var SHIMS = []string{
 const DEFAULT_PERMISSION = 0775
 
 func writeShim(shimPath string) error {
-	shimContent := []byte("#!/bin/bash\n$(vm where) $@")
+	shimContent := []byte("#!/bin/bash\n$(v where) $@")
 	if err := os.WriteFile(shimPath, shimContent, DEFAULT_PERMISSION); err != nil {
 		return err
 	}


### PR DESCRIPTION
The autogeneated shims were previously using `vm where` to detect which runtime path is selected -- this is a reference to a previous name for the executable.