### PR TITLE
refactor: url.JoinPath and state path.Join abstraction instead of fmt…

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -97,8 +97,7 @@ func ListVersions(args []string, flags Flags, currentState State) error {
 func Where(args []string, flags Flags, currentState State) error {
 	version := currentState.GlobalVersion
 	tag := VersionStringToStruct(version)
-	withoutPatch := fmt.Sprintf("%s.%s", tag.Major, tag.Minor)
-	fmt.Println(GetStatePath("runtimes", fmt.Sprintf("py-%s", currentState.GlobalVersion), "bin", fmt.Sprintf("python%s", withoutPatch)))
+	fmt.Println(GetStatePath("runtimes", fmt.Sprintf("py-%s", currentState.GlobalVersion), "bin", fmt.Sprintf("python%s", tag.MajorMinor())))
 	return nil
 }
 

--- a/commands.go
+++ b/commands.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"strings"
 )
 
@@ -33,21 +32,19 @@ func writeShim(shimPath string) error {
 // Sets up directories and files used to store downloaded archives,
 // installed runtimes and metadata.
 func Initialize(args []string, flags Flags, currentState State) error {
-	stateDirectory := GetStateDirectory()
-
-	os.Mkdir(stateDirectory, DEFAULT_PERMISSION)
+	os.Mkdir(GetStatePath(), DEFAULT_PERMISSION)
 	for _, dir := range DIRECTORIES {
-		os.Mkdir(GetPathFromStateDirectory(dir), DEFAULT_PERMISSION)
+		os.Mkdir(GetStatePath(dir), DEFAULT_PERMISSION)
 	}
 
 	for _, shim := range SHIMS {
-		writeShim(GetPathFromStateDirectory(path.Join("shims", shim)))
+		writeShim(GetStatePath("shims", shim))
 	}
 
 	return nil
 }
 func UninstallPython(args []string, flags Flags, currentState State) error {
-	runtimePath := GetPathFromStateDirectory(path.Join("runtimes", fmt.Sprintf("py-%s", args[1])))
+	runtimePath := GetStatePath("runtimes", fmt.Sprintf("py-%s", args[1]))
 	err := os.RemoveAll(runtimePath)
 	return err
 }
@@ -78,7 +75,7 @@ func Use(args []string, flags Flags, currentState State) error {
 	return nil
 }
 func ListVersions(args []string, flags Flags, currentState State) error {
-	runtimesDir := GetPathFromStateDirectory("runtimes")
+	runtimesDir := GetStatePath("runtimes")
 	entries, err := os.ReadDir(runtimesDir)
 
 	if err != nil {
@@ -101,7 +98,7 @@ func Where(args []string, flags Flags, currentState State) error {
 	version := currentState.GlobalVersion
 	tag := VersionStringToStruct(version)
 	withoutPatch := fmt.Sprintf("%s.%s", tag.Major, tag.Minor)
-	fmt.Printf("%s/runtimes/py-%s/bin/python%s\n", GetStateDirectory(), currentState.GlobalVersion, withoutPatch)
+	fmt.Println(GetStatePath("runtimes", fmt.Sprintf("py-%s", currentState.GlobalVersion), "bin", fmt.Sprintf("python%s", withoutPatch)))
 	return nil
 }
 

--- a/install_python.go
+++ b/install_python.go
@@ -26,6 +26,10 @@ type VersionTag struct {
 	Patch string
 }
 
+func (t VersionTag) MajorMinor() string {
+	return fmt.Sprintf("%s.%s", t.Major, t.Minor)
+}
+
 func InstallPython(args []string, flags Flags, currentState State) error {
 	verbose := flags.Verbose
 	version := args[1]

--- a/install_python.go
+++ b/install_python.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"strings"
@@ -50,8 +51,8 @@ func InstallPython(args []string, flags Flags, currentState State) error {
 // Fetches the Python tarball for version <version> from python.org.
 func downloadSource(version string, skipCache bool) (PackageMetadata, error) {
 	archiveName := fmt.Sprintf("Python-%s.tgz", version)
-	archivePath := GetPathFromStateDirectory(path.Join("cache", archiveName))
-	sourceUrl := fmt.Sprintf("%s/%s/%s", pythonReleasesBaseURL, version, archiveName)
+	archivePath := GetStatePath("cache", archiveName)
+	sourceUrl, _ := url.JoinPath(pythonReleasesBaseURL, version, archiveName)
 
 	client := http.Client{}
 
@@ -87,7 +88,7 @@ func buildFromSource(pkgMeta PackageMetadata, verbose bool) (PackageMetadata, er
 
 	buildPrint(fmt.Sprintf("Unpacking source for %s", pkgMeta.ArchivePath))
 
-	_, untarErr := RunCommand([]string{"tar", "zxvf", pkgMeta.ArchivePath}, GetPathFromStateDirectory("cache"), !verbose)
+	_, untarErr := RunCommand([]string{"tar", "zxvf", pkgMeta.ArchivePath}, GetStatePath("cache"), !verbose)
 
 	if untarErr != nil {
 		return pkgMeta, untarErr
@@ -97,7 +98,7 @@ func buildFromSource(pkgMeta PackageMetadata, verbose bool) (PackageMetadata, er
 
 	buildPrint("Configuring installer")
 
-	targetDirectory := GetPathFromStateDirectory(path.Join("runtimes", fmt.Sprintf("py-%s", pkgMeta.Version)))
+	targetDirectory := GetStatePath("runtimes", fmt.Sprintf("py-%s", pkgMeta.Version))
 
 	_, configureErr := RunCommand([]string{"./configure", fmt.Sprintf("--prefix=%s", targetDirectory), "--enable-optimizations"}, unzippedRoot, !verbose)
 

--- a/state.go
+++ b/state.go
@@ -14,7 +14,7 @@ type State struct {
 	GlobalVersion string `json:"globalVersion"`
 }
 
-func GetStateDirectory() string {
+func GetStatePath(pathSegments ...string) string {
 	home, _ := os.UserHomeDir()
 	userDefinedRoot, found := os.LookupEnv("V_ROOT")
 
@@ -23,16 +23,13 @@ func GetStateDirectory() string {
 	if found {
 		root = userDefinedRoot
 	}
-
-	return root
-}
-
-func GetPathFromStateDirectory(suffix string) string {
-	return path.Join(GetStateDirectory(), suffix)
+	allSegments := []string{root}
+	allSegments = append(allSegments, pathSegments...)
+	return path.Join(allSegments...)
 }
 
 func ReadState() State {
-	c, _ := ioutil.ReadFile(GetPathFromStateDirectory("state.json"))
+	c, _ := ioutil.ReadFile(GetStatePath("state.json"))
 
 	state := State{}
 
@@ -45,11 +42,11 @@ func WriteState(version string) {
 	state := State{GlobalVersion: version}
 
 	d, _ := json.Marshal(state)
-	ioutil.WriteFile(GetPathFromStateDirectory("state.json"), d, 0750)
+	ioutil.WriteFile(GetStatePath("state.json"), d, 0750)
 }
 
 func GetAvailableVersions() []string {
-	entries, _ := os.ReadDir(GetPathFromStateDirectory("runtimes"))
+	entries, _ := os.ReadDir(GetStatePath("runtimes"))
 
 	versions := []string{}
 


### PR DESCRIPTION
….Sprintf

`fmt.Sprintf` was used in a few places to handle path-building instead of `url.JoinPath` or `path.Join`. This fixes that.

`GetStatePath` is now the correct way of building a path for resources that live in the state directory (as opposed to a combination of `path.Join` and `GetPathFromStateDirectory`); this also allows folding in `GetStateDirectory` into `GetStatePath` entirely -- providing no arguments has the same behaviour.

The URL that leads to specific runtime versions was built using `fmt.Sprintf` before, now is using the more correct `url.JoinPath`.