### PR TITLE
feat: easier path setup through `init --add-path`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,15 @@ Pre-built binaries are not currently available. You can clone the repository and
 You should find a suitable place for the binary (`/usr/local/bin` is a good location) and if not already included, add its location to `$PATH`.
 
 Finally, run `v init` to create directories to store artifacts and state (under `~/.v` unless override using the
-`V_ROOT` environment variable) and add `~/.v/shims` to your `$PATH` as well.
+`V_ROOT` environment variable). The following should also be added to your shell's configuration (i.e. `.zshrc`,
+`.bashrc`, ...):
+
+```sh
+export PATH=<path-to-v-executable>:$PATH
+eval "$(v init --add-path)"
+```
+
+This will handle adding shim paths to your shell without hassle.
 
 ### Usage
 

--- a/cli.go
+++ b/cli.go
@@ -6,6 +6,7 @@ import (
 )
 
 type Flags struct {
+	AddPath bool
 	NoCache bool
 	Verbose bool
 }
@@ -91,10 +92,13 @@ func collectFlags(args []string) Flags {
 			continue
 		}
 
-		if arg == "--verbose" {
+		switch arg {
+		case "--verbose":
 			collected.Verbose = true
-		} else if arg == "--no-cache" {
+		case "--no-cache":
 			collected.NoCache = true
+		case "--add-path":
+			collected.AddPath = true
 		}
 	}
 

--- a/commands.go
+++ b/commands.go
@@ -32,6 +32,11 @@ func writeShim(shimPath string) error {
 // Sets up directories and files used to store downloaded archives,
 // installed runtimes and metadata.
 func Initialize(args []string, flags Flags, currentState State) error {
+	if flags.AddPath {
+		fmt.Printf("export PATH=%s:$PATH\n", GetStatePath("shims"))
+		return nil
+	}
+
 	os.Mkdir(GetStatePath(), DEFAULT_PERMISSION)
 	for _, dir := range DIRECTORIES {
 		os.Mkdir(GetStatePath(dir), DEFAULT_PERMISSION)

--- a/v.go
+++ b/v.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	Version  = "0.0.2"
+	Version  = "0.0.3"
 	Author   = "Marc Cataford <hello@karnov.club>"
 	Homepage = "https://github.com/mcataford/v"
 )


### PR DESCRIPTION
This updates the `init` command to allow passing in `--add-path`, which facilitates setting up `$PATH` correctly with shims. The README is updated accordingly to reflect the expected shell configuration changes when installing `v`.