### PR TITLE
ci: add basic integration test, pipeline step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,9 @@ name: "v CI/CD"
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   integration-tests:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,17 @@
+name: "v CI/CD"
+
+on:
+  pull_request:
+
+jobs:
+  integration-tests:
+    name: "Integration tests"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - run: . integration/install_specific_version
+        env:
+          V_ROOT: /tmp/v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,11 +7,11 @@ jobs:
   integration-tests:
     name: "Integration tests"
     runs-on: ubuntu-latest
+    env:
+      V_ROOT: /tmp/v
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version: '1.21'
       - run: . integration/install_specific_version
-        env:
-          V_ROOT: /tmp/v

--- a/integration/install_specific_version
+++ b/integration/install_specific_version
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Scenario: User installs a specific version of python.
+
+echo "Scenario: User installs a specific version of Python"
+
+go build .
+
+TARGET_VERSION="3.10.0"
+
+V_ROOT=/tmp/v ./v init
+V_ROOT=/tmp/v ./v install $TARGET_VERSION --no-cache
+
+INSTALLED_VERSIONS=$(V_ROOT=/tmp/v ./v ls)
+
+if [ -z "$(echo $INSTALLED_VERSIONS | grep $TARGET_VERSION)" ]; then
+    echo "FAIL: Could not find target version."
+    exit 1
+else
+    echo "SUCCESS"
+fi


### PR DESCRIPTION
Sets up a CI stub to run basic integration tests. The only case covered is installing a python version via `v install`.