### PR TITLE
perf: use -j to build on multiple cores

### DIFF
--- a/install_python.go
+++ b/install_python.go
@@ -111,7 +111,7 @@ func buildFromSource(pkgMeta PackageMetadata, verbose bool) (PackageMetadata, er
 	}
 
 	buildPrint("Building")
-	_, buildErr := RunCommand([]string{"make", "altinstall"}, unzippedRoot, !verbose)
+	_, buildErr := RunCommand([]string{"make", "altinstall", "-j4"}, unzippedRoot, !verbose)
 
 	if buildErr != nil {
 		return pkgMeta, buildErr

--- a/v.go
+++ b/v.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	Version  = "0.0.3"
+	Version  = "0.0.4"
 	Author   = "Marc Cataford <hello@karnov.club>"
 	Homepage = "https://github.com/mcataford/v"
 )


### PR DESCRIPTION
Previous, the build process of `v install <version>` didn't take advantage of the `-jX` flag that enables using up to X cores to speed up building. This reduces build times by half, anecdotally / on my machine -- gains are expected on any building machine that has enough cores to spread the workload.