### PR TITLE
feat: default to system python if no version specified

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"slices"
 	"strings"
 )
 
@@ -132,35 +131,4 @@ func Which(args []string, flags Flags, currentState State) error {
 
 	fmt.Println(selectedVersion)
 	return nil
-}
-
-// DetermineSelectedPythonVersion returns the Python runtime version that should be
-// used according to v.
-//
-// By default, 'SYSTEM' is returned, which signals that the non-v-managed Python
-// runtime is used.
-func DetermineSelectedPythonVersion(currentState State) (string, error) {
-	if len(currentState.GlobalVersion) != 0 {
-		return currentState.GlobalVersion, nil
-	}
-
-	return "SYSTEM", nil
-}
-
-// DetermineSystemPython returns the unshimmed Python version and path.
-// This is done by inspected the output of `which` and `python --version` if v's shims
-// are not in $PATH.
-func DetermineSystemPython() (string, string) {
-	currentPathEnv := os.Getenv("PATH")
-	pathWithoutShims := slices.DeleteFunc(strings.Split(currentPathEnv, ":"), func(element string) bool {
-		return element == GetStatePath("shims")
-	})
-	// FIXME: This should be set through RunCommand instead.
-	os.Setenv("PATH", strings.Join(pathWithoutShims, ":"))
-	whichOut, _ := RunCommand([]string{"which", "python"}, ".", true)
-	versionOut, _ := RunCommand([]string{"python", "--version"}, ".", true)
-
-	detectedVersion, _ := strings.CutPrefix(versionOut, "Python ")
-
-	return detectedVersion, whichOut
 }

--- a/commands.go
+++ b/commands.go
@@ -19,7 +19,6 @@ var SHIMS = []string{
 }
 
 const DEFAULT_PERMISSION = 0775
-const DEFAULT_SYSTEM_PY_PATH = "/bin/python"
 
 func writeShim(shimPath string) error {
 	shimContent := []byte("#!/bin/bash\n$(v where) $@")

--- a/pythonversion.go
+++ b/pythonversion.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+	"slices"
+	"strings"
+)
+
+// DetermineSelectedPythonVersion returns the Python runtime version that should be
+// used according to v.
+//
+// By default, 'SYSTEM' is returned, which signals that the non-v-managed Python
+// runtime is used.
+func DetermineSelectedPythonVersion(currentState State) (string, error) {
+	if len(currentState.GlobalVersion) != 0 {
+		return currentState.GlobalVersion, nil
+	}
+
+	return "SYSTEM", nil
+}
+
+// DetermineSystemPython returns the unshimmed Python version and path.
+// This is done by inspected the output of `which` and `python --version` if v's shims
+// are not in $PATH.
+func DetermineSystemPython() (string, string) {
+	currentPathEnv := os.Getenv("PATH")
+	pathWithoutShims := slices.DeleteFunc(strings.Split(currentPathEnv, ":"), func(element string) bool {
+		return element == GetStatePath("shims")
+	})
+	// FIXME: This should be set through RunCommand instead.
+	os.Setenv("PATH", strings.Join(pathWithoutShims, ":"))
+	whichOut, _ := RunCommand([]string{"which", "python"}, ".", true)
+	versionOut, _ := RunCommand([]string{"python", "--version"}, ".", true)
+
+	detectedVersion, _ := strings.CutPrefix(versionOut, "Python ")
+
+	return detectedVersion, whichOut
+}

--- a/pythonversion.go
+++ b/pythonversion.go
@@ -29,10 +29,10 @@ func DetermineSystemPython() (string, string) {
 	})
 	// FIXME: This should be set through RunCommand instead.
 	os.Setenv("PATH", strings.Join(pathWithoutShims, ":"))
-	whichOut, _ := RunCommand([]string{"which", "python"}, ".", true)
-	versionOut, _ := RunCommand([]string{"python", "--version"}, ".", true)
+	whichOut, _ := RunCommand([]string{"which", "python"}, GetStatePath(), true)
+	versionOut, _ := RunCommand([]string{"python", "--version"}, GetStatePath(), true)
 
-	detectedVersion, _ := strings.CutPrefix(versionOut, "Python ")
+	detectedVersion, _ := strings.CutPrefix(versionOut, "Python")
 
-	return detectedVersion, whichOut
+	return strings.TrimSpace(detectedVersion), strings.TrimSpace(whichOut)
 }

--- a/pythonversion_test.go
+++ b/pythonversion_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+// SetupAndCleanupEnvironment sets up a test directory and
+// environment variables before the test and returns a cleanup
+// function that can be deferred to cleanup any changes to the
+// system.
+func SetupAndCleanupEnvironment(t *testing.T) func() {
+	os.Setenv("V_ROOT", t.TempDir())
+
+	return func() {
+		os.Unsetenv("V_ROOT")
+	}
+}
+
+func TestDetermineSystemPythonGetsUnshimmedPythonRuntime(t *testing.T) {
+	defer SetupAndCleanupEnvironment(t)()
+
+	ioutil.WriteFile(GetStatePath("shims", "python"), []byte("#!/bin/bash\necho \"Python 4.5.6\""), 0777)
+	mockSystemPythonPath := t.TempDir()
+	mockSystemPythonExecPath := path.Join(mockSystemPythonPath, "python")
+	ioutil.WriteFile(mockSystemPythonExecPath, []byte("#!/bin/bash\necho \"Python 1.2.3\""), 0777)
+
+	oldPath := os.Getenv("PATH")
+	os.Setenv("PATH", fmt.Sprintf("%s:%s:/usr/bin", GetStatePath("shims"), mockSystemPythonPath))
+	defer os.Setenv("PATH", oldPath)
+	sysVersion, sysPath := DetermineSystemPython()
+
+	if sysVersion != "1.2.3" {
+		t.Errorf("Expected system Python to be 1.2.3, found %s instead.", sysVersion)
+	}
+
+	if sysPath != mockSystemPythonExecPath {
+		t.Errorf("Expected system Python path to be %s, found %s instead.", mockSystemPythonExecPath, sysPath)
+	}
+}
+
+func TestDetermineSelectedPythonVersionGetsUserDefinedVersion(t *testing.T) {
+	defer SetupAndCleanupEnvironment(t)()
+
+	// Writing a mock user-defined state.
+	mockState := State{GlobalVersion: "1.0.0"}
+	statePath := GetStatePath("state.json")
+	stateData, _ := json.Marshal(mockState)
+	ioutil.WriteFile(statePath, stateData, 0750)
+
+	version, err := DetermineSelectedPythonVersion(ReadState())
+
+	if err != nil || version != mockState.GlobalVersion {
+		t.Errorf("Expected version to be %s, got %s instead.", mockState.GlobalVersion, version)
+	}
+}
+
+func TestDetermineSelectedPythonVersionDefaultsToSystem(t *testing.T) {
+	defer SetupAndCleanupEnvironment(t)
+
+	version, err := DetermineSelectedPythonVersion(ReadState())
+
+	if err != nil || version != "SYSTEM" {
+		t.Errorf("Expected version to be 'SYSTEM', got %s instead.", version)
+	}
+}

--- a/util.go
+++ b/util.go
@@ -30,19 +30,28 @@ func ValidateVersion(version string) error {
 	return nil
 }
 
+// RunCommand is a thin wrapper around running command-line calls
+// programmatically. It abstracts common configuration like routing
+// output and handling the directory the calls are made from.
 func RunCommand(command []string, cwd string, quiet bool) (string, error) {
 	cmd := exec.Command(command[0], command[1:]...)
 
 	cmd.Dir = cwd
 
+	var out strings.Builder
+	var errOut strings.Builder
+
 	if !quiet {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
+	} else {
+		cmd.Stdout = &out
+		cmd.Stderr = &errOut
 	}
 
 	if err := cmd.Run(); err != nil {
-		return "", err
+		return errOut.String(), err
 	}
 
-	return "", nil
+	return out.String(), nil
 }

--- a/v.go
+++ b/v.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	Version  = "0.0.4"
+	Version  = "0.0.5"
 	Author   = "Marc Cataford <hello@karnov.club>"
 	Homepage = "https://github.com/mcataford/v"
 )


### PR DESCRIPTION
# Description

Previously, `v which` would have undefined behaviour around scenarios where no version was specified or available (i.e. no configuration detected). In these cases, you'd expect the system-defined Python to be used as a fallback since `v` cannot supply a user-defined version.

This implements that:

- `where` is made to return the Python path that would apply if `v` had no shims;
- `which` is made to return the output of `python --version` using the path above.

# QA

- With no configuration file available, check `v which` and `v where`.
- :heavy_check_mark: Confirm that the system Python is returned.
- Set up a configuration file with an installed version, repeat.
- :heavy_check_mark: Confirm that the v-controlled Python is used.