### PR TITLE
feat: better formatting for which/where printouts

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -6,9 +6,10 @@ import (
 )
 
 type Flags struct {
-	AddPath bool
-	NoCache bool
-	Verbose bool
+	AddPath   bool
+	NoCache   bool
+	Verbose   bool
+	RawOutput bool
 }
 
 // Command definition for CLI subcommands.
@@ -99,6 +100,8 @@ func collectFlags(args []string) Flags {
 			collected.NoCache = true
 		case "--add-path":
 			collected.AddPath = true
+		case "--raw":
+			collected.RawOutput = true
 		}
 	}
 

--- a/style.go
+++ b/style.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+const (
+	RESET = "\033[0m"
+	BOLD  = "\033[1m"
+)
+
+func Bold(text string) string {
+	return fmt.Sprintf("%s%s%s", BOLD, text, RESET)
+}

--- a/v.go
+++ b/v.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	Version  = "0.0.5"
+	Version  = "0.0.6"
 	Author   = "Marc Cataford <hello@karnov.club>"
 	Homepage = "https://github.com/mcataford/v"
 )


### PR DESCRIPTION
# Description

This improves the formatting of `where` and `which` calls and offers a `--raw` flag to print without formatting or prefixes (this is now used in shims).

# QA

- Call `which` without a configuration (system).
- :heavy_check_mark: Verify that the output has styling and is the system Python version.
- Call `where` without a configuration (system).
- :heavy_check_mark: Verify that the output has styling and is the system Python path.
- Repeat with a configuration file (i.e. after using `v use <version>`), confirm the styling and prefixes are not present.