### PR TITLE
feat: support .python-version to set version

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -104,8 +104,10 @@ func Where(args []string, flags Flags, currentState State) error {
 	selectedVersion, _ := DetermineSelectedPythonVersion(currentState)
 
 	var printedPath string
+
 	if selectedVersion == "SYSTEM" {
-		_, printedPath = DetermineSystemPython()
+		_, sysPath := DetermineSystemPython()
+		printedPath = fmt.Sprintf("%s (system)", sysPath)
 	} else {
 		tag := VersionStringToStruct(selectedVersion)
 		printedPath = GetStatePath("runtimes", fmt.Sprintf("py-%s", selectedVersion), "bin", fmt.Sprintf("python%s", tag.MajorMinor()))

--- a/pythonversion.go
+++ b/pythonversion.go
@@ -17,7 +17,7 @@ func SearchForPythonVersionFile() (string, bool) {
 		content, err := ioutil.ReadFile(path.Join(currentPath, ".python-version"))
 
 		if err == nil {
-			versionFound = string(content)
+			versionFound = strings.TrimSpace(string(content))
 			break
 		}
 
@@ -62,8 +62,11 @@ func DetermineSystemPython() (string, string) {
 	pathWithoutShims := slices.DeleteFunc(strings.Split(currentPathEnv, ":"), func(element string) bool {
 		return element == GetStatePath("shims")
 	})
+
 	// FIXME: This should be set through RunCommand instead.
 	os.Setenv("PATH", strings.Join(pathWithoutShims, ":"))
+	defer os.Setenv("PATH", currentPathEnv)
+
 	whichOut, _ := RunCommand([]string{"which", "python"}, GetStatePath(), true)
 	versionOut, _ := RunCommand([]string{"python", "--version"}, GetStatePath(), true)
 


### PR DESCRIPTION
# Description

Adds support for using `.python-version` in the current working directory or in a parent directory to set the current version.

# QA

- Add a `.python-version` file to the CWD.
- :heavy_check_mark: Verify that `v where` and `v which` use it and return its version.
- Move the file up a directory and repeat.
- :heavy_check_mark: Verify that `v where` and `v which` use it and return its version.
- Repeat without the `.python-version` file.
- :heavy_check_mark: Verify that the system version is used.