### PR TITLE
feat: which + version commands

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -21,7 +21,7 @@ var SHIMS = []string{
 const DEFAULT_PERMISSION = 0775
 
 func writeShim(shimPath string) error {
-	shimContent := []byte("#!/bin/bash\n$(v where --raw) $@")
+	shimContent := []byte("#!/bin/bash\n$(v which --raw) $@")
 	if err := os.WriteFile(shimPath, shimContent, DEFAULT_PERMISSION); err != nil {
 		return err
 	}

--- a/commands.go
+++ b/commands.go
@@ -99,8 +99,8 @@ func ListVersions(args []string, flags Flags, currentState State) error {
 	return nil
 }
 
-// Where prints out the system path to the executable being used by `python`.
-func Where(args []string, flags Flags, currentState State) error {
+// Which prints out the system path to the executable being used by `python`.
+func Which(args []string, flags Flags, currentState State) error {
 	selectedVersion, _ := DetermineSelectedPythonVersion(currentState)
 
 	var printedPath string
@@ -110,7 +110,7 @@ func Where(args []string, flags Flags, currentState State) error {
 		printedPath = fmt.Sprintf("%s (system)", sysPath)
 	} else {
 		tag := VersionStringToStruct(selectedVersion.Version)
-		printedPath = GetStatePath("runtimes", fmt.Sprintf("py-%s", selectedVersion), "bin", fmt.Sprintf("python%s", tag.MajorMinor()))
+		printedPath = GetStatePath("runtimes", fmt.Sprintf("py-%s", selectedVersion.Version), "bin", fmt.Sprintf("python%s", tag.MajorMinor()))
 	}
 
 	prefix := "Python path: "
@@ -125,28 +125,17 @@ func Where(args []string, flags Flags, currentState State) error {
 	return nil
 }
 
-// Which prints out the Python version that will be used by shims. It can be invoked
-// directly by the `v which` command.
-//
-// If no version is set (i.e. none is installed, the specified version is not installed),
-// the system version is used and 'SYSTEM' is printed by Which.
-func Which(args []string, flags Flags, currentState State) error {
+// CurrentVersion (called via `v version`) outputs the currently selected version
+// and what configures it. If the version is configured by a file, the file is returned
+// under "source", if the system Python is used, "system" is returned as a source.
+func CurrentVersion(args []string, flags Flags, currentState State) error {
 	selectedVersion, _ := DetermineSelectedPythonVersion(currentState)
-	printedVersion := selectedVersion.Version
-
-	if selectedVersion.Source == "system" {
-		sysVersion, _ := DetermineSystemPython()
-		printedVersion = fmt.Sprintf("%s (system)", sysVersion)
-	}
-
-	prefix := "Python version: "
 
 	if flags.RawOutput {
-		prefix = ""
-	} else {
-		printedVersion = Bold(printedVersion)
+		fmt.Println(selectedVersion.Version)
+		return nil
 	}
 
-	fmt.Printf("%s%s\n", prefix, printedVersion)
+	fmt.Printf("Python version: %s\nSource: %s\n", Bold(selectedVersion.Version), Bold(selectedVersion.Source))
 	return nil
 }

--- a/commands.go
+++ b/commands.go
@@ -105,11 +105,11 @@ func Where(args []string, flags Flags, currentState State) error {
 
 	var printedPath string
 
-	if selectedVersion == "SYSTEM" {
+	if selectedVersion.Source == "system" {
 		_, sysPath := DetermineSystemPython()
 		printedPath = fmt.Sprintf("%s (system)", sysPath)
 	} else {
-		tag := VersionStringToStruct(selectedVersion)
+		tag := VersionStringToStruct(selectedVersion.Version)
 		printedPath = GetStatePath("runtimes", fmt.Sprintf("py-%s", selectedVersion), "bin", fmt.Sprintf("python%s", tag.MajorMinor()))
 	}
 
@@ -132,9 +132,9 @@ func Where(args []string, flags Flags, currentState State) error {
 // the system version is used and 'SYSTEM' is printed by Which.
 func Which(args []string, flags Flags, currentState State) error {
 	selectedVersion, _ := DetermineSelectedPythonVersion(currentState)
-	printedVersion := selectedVersion
+	printedVersion := selectedVersion.Version
 
-	if selectedVersion == "SYSTEM" {
+	if selectedVersion.Source == "system" {
 		sysVersion, _ := DetermineSystemPython()
 		printedVersion = fmt.Sprintf("%s (system)", sysVersion)
 	}

--- a/pythonversion.go
+++ b/pythonversion.go
@@ -4,13 +4,17 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"slices"
 	"strings"
 )
 
+type SelectedVersion struct {
+	Version string
+	Source  string
+}
+
 // SearchForPythonVersionFile crawls up to the system root to find any
 // .python-version file that could set the current version.
-func SearchForPythonVersionFile() (string, bool) {
+func SearchForPythonVersionFile() (SelectedVersion, bool) {
 	currentPath, _ := os.Getwd()
 	var versionFound string
 	for {
@@ -30,7 +34,11 @@ func SearchForPythonVersionFile() (string, bool) {
 		currentPath = nextPath
 	}
 
-	return versionFound, versionFound != ""
+	if versionFound == "" {
+		return SelectedVersion{}, false
+	}
+
+	return SelectedVersion{Version: versionFound, Source: path.Join(currentPath, ".python-version")}, true
 }
 
 // DetermineSelectedPythonVersion returns the Python runtime version that should be
@@ -40,7 +48,7 @@ func SearchForPythonVersionFile() (string, bool) {
 // file that would indicate which version is preferred. If none are found, the global
 // user-defined version (via `v use <version>`) is used. If there is none, the system
 // Python version is used.
-func DetermineSelectedPythonVersion(currentState State) (string, error) {
+func DetermineSelectedPythonVersion(currentState State) (SelectedVersion, error) {
 	pythonFileVersion, pythonFileVersionFound := SearchForPythonVersionFile()
 
 	if pythonFileVersionFound {
@@ -48,29 +56,17 @@ func DetermineSelectedPythonVersion(currentState State) (string, error) {
 	}
 
 	if len(currentState.GlobalVersion) != 0 {
-		return currentState.GlobalVersion, nil
+		return SelectedVersion{Version: currentState.GlobalVersion, Source: ""}, nil
 	}
 
-	return "SYSTEM", nil
+	systemVersion, _ := DetermineSystemPython()
+	return SelectedVersion{Source: "system", Version: systemVersion}, nil
 }
 
 // DetermineSystemPython returns the unshimmed Python version and path.
-// This is done by inspected the output of `which` and `python --version` if v's shims
-// are not in $PATH.
+// It assumes that /bin/python is where system Python lives.
 func DetermineSystemPython() (string, string) {
-	currentPathEnv := os.Getenv("PATH")
-	pathWithoutShims := slices.DeleteFunc(strings.Split(currentPathEnv, ":"), func(element string) bool {
-		return element == GetStatePath("shims")
-	})
-
-	// FIXME: This should be set through RunCommand instead.
-	os.Setenv("PATH", strings.Join(pathWithoutShims, ":"))
-	defer os.Setenv("PATH", currentPathEnv)
-
-	whichOut, _ := RunCommand([]string{"which", "python"}, GetStatePath(), true)
-	versionOut, _ := RunCommand([]string{"python", "--version"}, GetStatePath(), true)
-
+	versionOut, _ := RunCommand([]string{"/bin/python", "--version"}, GetStatePath(), true)
 	detectedVersion, _ := strings.CutPrefix(versionOut, "Python")
-
-	return strings.TrimSpace(detectedVersion), strings.TrimSpace(whichOut)
+	return strings.TrimSpace(detectedVersion), "/bin/python"
 }

--- a/pythonversion.go
+++ b/pythonversion.go
@@ -56,7 +56,7 @@ func DetermineSelectedPythonVersion(currentState State) (SelectedVersion, error)
 	}
 
 	if len(currentState.GlobalVersion) != 0 {
-		return SelectedVersion{Version: currentState.GlobalVersion, Source: ""}, nil
+		return SelectedVersion{Version: currentState.GlobalVersion, Source: GetStatePath("state.json")}, nil
 	}
 
 	systemVersion, _ := DetermineSystemPython()

--- a/v.go
+++ b/v.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	Version  = "0.0.6"
+	Version  = "0.0.7"
 	Author   = "Marc Cataford <hello@karnov.club>"
 	Homepage = "https://github.com/mcataford/v"
 )

--- a/v.go
+++ b/v.go
@@ -30,9 +30,9 @@ func main() {
 	).AddCommand(
 		"ls", ListVersions, "v ls", "Lists the installed Python versions.",
 	).AddCommand(
-		"where", Where, "v where", "Prints the path to the current Python version.",
+		"version", CurrentVersion, "v version", "Prints the current version and its source.",
 	).AddCommand(
-		"which", Which, "v which", "Prints the current Python version.",
+		"which", Which, "v which", "Prints the path to the current Python version.",
 	).AddCommand(
 		"init", Initialize, "v init", "Initializes the v state.",
 	).Run(args, currentState)


### PR DESCRIPTION
# Description

This updates the command-line options so that `which` aligns with the *nix expectations (i.e. prints path to executable). `v version` is introduced to cater to what `v which` previously did, i.e. print the current version and its source. If the `--raw` flag is used, `v version` only outputs the version.

# QA

- Used `v which` and `v version` with and without the `--raw` flag.
- :heavy_check_mark: Verify that the output is as expected.