### PR TITLE
feat: handling for using versions that are not installed

### DIFF
--- a/install_python.go
+++ b/install_python.go
@@ -30,15 +30,12 @@ func (t VersionTag) MajorMinor() string {
 	return fmt.Sprintf("%s.%s", t.Major, t.Minor)
 }
 
-func InstallPython(args []string, flags Flags, currentState State) error {
-	verbose := flags.Verbose
-	version := args[1]
-
+func InstallPythonDistribution(version string, noCache bool, verbose bool) error {
 	if err := ValidateVersion(version); err != nil {
 		return err
 	}
 
-	packageMetadata, dlerr := downloadSource(version, flags.NoCache)
+	packageMetadata, dlerr := downloadSource(version, noCache)
 
 	if dlerr != nil {
 		return dlerr

--- a/pythonversion.go
+++ b/pythonversion.go
@@ -12,6 +12,23 @@ type SelectedVersion struct {
 	Source  string
 }
 
+func ListInstalledVersions() ([]string, error) {
+	runtimesDir := GetStatePath("runtimes")
+	entries, err := os.ReadDir(runtimesDir)
+
+	if err != nil {
+		return []string{}, err
+	}
+
+	installedVersions := []string{}
+
+	for _, d := range entries {
+		installedVersions = append(installedVersions, strings.TrimPrefix(d.Name(), "py-"))
+	}
+
+	return installedVersions, nil
+}
+
 // SearchForPythonVersionFile crawls up to the system root to find any
 // .python-version file that could set the current version.
 func SearchForPythonVersionFile() (SelectedVersion, bool) {

--- a/pythonversion_test.go
+++ b/pythonversion_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"slices"
 	"testing"
 )
 
@@ -131,5 +132,47 @@ func TestSearchForPythonVersionFileReturnsOnRootIfNoneFound(t *testing.T) {
 	if versionFound.Version != "" || found {
 		t.Errorf("Did not expect any result, found %s.", versionFound.Version)
 	}
+}
 
+func TestListInstalledVersion(t *testing.T) {
+	defer SetupAndCleanupEnvironment(t)()
+
+	versions := []string{"1.2.3", "4.5.6", "7.8.9"}
+
+	os.Mkdir(GetStatePath("runtimes"), 0750)
+	for _, version := range versions {
+		os.Mkdir(GetStatePath("runtimes", "py-"+version), 0750)
+	}
+
+	installedVersions, _ := ListInstalledVersions()
+
+	if !slices.Equal(installedVersions, versions) {
+		t.Errorf("Expected %s, got %s.", versions, installedVersions)
+	}
+}
+
+func TestListInstalledVersionNoVersionsInstalled(t *testing.T) {
+	defer SetupAndCleanupEnvironment(t)()
+
+	os.Mkdir(GetStatePath("runtimes"), 0750)
+
+	installedVersions, _ := ListInstalledVersions()
+
+	if len(installedVersions) != 0 {
+		t.Errorf("Expected 0 elements, got %d (%s).", len(installedVersions), installedVersions)
+	}
+}
+
+func TestListInstalledVersionNoRuntimesDir(t *testing.T) {
+	defer SetupAndCleanupEnvironment(t)()
+
+	installedVersions, err := ListInstalledVersions()
+
+	if len(installedVersions) != 0 {
+		t.Errorf("Expected 0 elements, got %d (%s).", len(installedVersions), installedVersions)
+	}
+
+	if err == nil {
+		t.Errorf("Expected error to be returned, got nil.")
+	}
 }

--- a/style.go
+++ b/style.go
@@ -3,9 +3,14 @@ package main
 import "fmt"
 
 const (
-	RESET = "\033[0m"
-	BOLD  = "\033[1m"
+	RESET  = "\033[0m"
+	BOLD   = "\033[1m"
+	YELLOW = "\033[33m"
 )
+
+func Yellow(text string) string {
+	return fmt.Sprintf("%s%s%s", YELLOW, text, RESET)
+}
 
 func Bold(text string) string {
 	return fmt.Sprintf("%s%s%s", BOLD, text, RESET)

--- a/v.go
+++ b/v.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	Version  = "0.0.7"
+	Version  = "0.0.8"
 	Author   = "Marc Cataford <hello@karnov.club>"
 	Homepage = "https://github.com/mcataford/v"
 )


### PR DESCRIPTION
# Description

Previously, you could potentially define a preferred version via `.python-version` or the `v use` command that might not exist. In those cases, trying to use `python` would fail as the shim could not resolve to anything.

This fixes that by introducing some new behaviour:

- `v which` will warn that the desired version is not installed if used in that context.
- `v version` will warn that the desired version is not installed if used in that context.
- `v use <version>` will warn that the version is not installed, install it, and then use it.

# QA

- Try each of the commands above.
- :heavy_check_mark: Verify that when the selected version does not exist, the output warns the user.
- :heavy_check_mark: Verify that when use `use`, the version gets installed.

## Known gaps

The use of `fmt` and the install flow makes things hard to test. Splitting this work out of this PR to avoid making the change too large.