### PR TITLE
test: coverage for installed version listing, current bin path

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -57,5 +58,74 @@ func TestListVersionReturnsErrorOnFailure(t *testing.T) {
 
 	if err == nil {
 		t.Errorf("Expected error returned, did not get one.")
+	}
+}
+
+func TestListVersionOutputsVersionSelectedAndWarnsNotInstalled(t *testing.T) {
+	defer SetupAndCleanupEnvironment(t)()
+
+	var out bytes.Buffer
+
+	InfoLogger.SetOutput(&out)
+	defer InfoLogger.SetOutput(os.Stdout)
+
+	Which([]string{}, Flags{}, State{GlobalVersion: "1.2.3"})
+
+	captured := out.String()
+	if captured != "The desired version (1.2.3) is not installed.\n" {
+		t.Errorf("Unexpected message: %s", captured)
+	}
+}
+
+func TestWhichOutputsVersionSelectedIfInstalled(t *testing.T) {
+	defer SetupAndCleanupEnvironment(t)()
+
+	var out bytes.Buffer
+
+	InfoLogger.SetOutput(&out)
+	defer InfoLogger.SetOutput(os.Stdout)
+
+	os.MkdirAll(GetStatePath("runtimes", "py-1.2.3"), 0750)
+	Which([]string{}, Flags{}, State{GlobalVersion: "1.2.3"})
+
+	captured := strings.TrimSpace(out.String())
+	expected := GetStatePath("runtimes", "py-1.2.3", "bin", "python1.2")
+	if !strings.Contains(captured, expected) {
+		t.Errorf("Unexpected message: %s, not %s", captured, expected)
+	}
+}
+
+func TestWhichOutputsSystemVersionIfNoneSelected(t *testing.T) {
+	defer SetupAndCleanupEnvironment(t)()
+
+	var out bytes.Buffer
+
+	InfoLogger.SetOutput(&out)
+	defer InfoLogger.SetOutput(os.Stdout)
+
+	Which([]string{}, Flags{RawOutput: true}, State{})
+
+	captured := strings.TrimSpace(out.String())
+
+	if captured != "/bin/python (system)" {
+		t.Errorf("%s != %s", captured, "/bin/python (system)")
+	}
+}
+
+func TestWhichOutputsVersionWithoutPrefixesIfRawOutput(t *testing.T) {
+	defer SetupAndCleanupEnvironment(t)()
+
+	var out bytes.Buffer
+
+	InfoLogger.SetOutput(&out)
+	defer InfoLogger.SetOutput(os.Stdout)
+
+	os.MkdirAll(GetStatePath("runtimes", "py-1.2.3"), 0750)
+	Which([]string{}, Flags{RawOutput: true}, State{GlobalVersion: "1.2.3"})
+
+	captured := strings.TrimSpace(out.String())
+	expected := GetStatePath("runtimes", "py-1.2.3", "bin", "python1.2")
+	if captured != expected {
+		t.Errorf("Unexpected message: %s, not %s", captured, expected)
 	}
 }


### PR DESCRIPTION
# Description

Now that a proper logger is used (#15), commands outputting to the user are more testable. This fills in testing gaps related to user messaging.

This covers tests for `which` and `ls`.

# QA

Tests passing.