### PR TITLE
fix(init): ensure shims call namespaced which command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -21,7 +21,7 @@ var SHIMS = []string{
 const DEFAULT_PERMISSION = 0775
 
 func writeShim(shimPath string) error {
-	shimContent := []byte("#!/bin/bash\n$(v which --raw) $@")
+	shimContent := []byte("#!/bin/bash\n$(v python which --raw) $@")
 	if err := os.WriteFile(shimPath, shimContent, DEFAULT_PERMISSION); err != nil {
 		return err
 	}

--- a/commands_test.go
+++ b/commands_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+	state "v/state"
+	testutils "v/testutils"
+)
+
+func TestWriteShim(t *testing.T) {
+	defer testutils.SetupAndCleanupEnvironment(t)()
+
+	os.Mkdir(state.GetStatePath("shims"), 0775)
+	testShimPath := state.GetStatePath("shims", "testshim")
+	e := writeShim(testShimPath)
+
+	shimContent, _ := ioutil.ReadFile(testShimPath)
+
+	if e != nil {
+		t.Errorf("Errored while writing shim")
+	}
+
+	if !strings.Contains(string(shimContent), "$(v python which --raw) $@") {
+		t.Errorf("Expected shim to contain pass-through via 'which', got %s", shimContent)
+	}
+
+}


### PR DESCRIPTION
# Description

Shims created by `v init` are pass-throughs that call `v python which --raw` to get the real executable path. In this case, shims were still using the non-namespaced command and failing.