### PR TITLE
refactor(python): relocate py shims to module

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+	cli "v/cli"
+	python "v/python"
 	state "v/state"
 	testutils "v/testutils"
 )
@@ -26,4 +28,54 @@ func TestWriteShim(t *testing.T) {
 		t.Errorf("Expected shim to contain pass-through via 'which', got %s", shimContent)
 	}
 
+}
+
+func TestInitializeCreatesStateDirectories(t *testing.T) {
+	defer testutils.SetupAndCleanupEnvironment(t)()
+
+	err := Initialize([]string{}, cli.Flags{}, state.State{})
+
+	if err != nil {
+		t.Errorf("Unexpected error initializing")
+	}
+
+	if _, err = os.Stat(state.GetStatePath()); os.IsNotExist(err) {
+		t.Errorf("Root state directory not found")
+	}
+
+	if _, err = os.Stat(state.GetStatePath("shims")); os.IsNotExist(err) {
+		t.Errorf("Shims directory not found")
+	}
+
+	if _, err = os.Stat(state.GetStatePath("cache")); os.IsNotExist(err) {
+		t.Errorf("Cache directory not found")
+	}
+
+	if _, err = os.Stat(state.GetStatePath("runtimes")); os.IsNotExist(err) {
+		t.Errorf("Runtimes directory not found")
+	}
+}
+
+func TestInitializeCreatesAllPythonShims(t *testing.T) {
+	defer testutils.SetupAndCleanupEnvironment(t)()
+
+	err := Initialize([]string{}, cli.Flags{}, state.State{})
+
+	if err != nil {
+		t.Errorf("Unexpected error initializing")
+	}
+
+	expectedShims := python.Shims
+
+	for shimLabel, shimCall := range expectedShims {
+		shimContent, err := os.ReadFile(state.GetStatePath("shims", shimLabel))
+
+		if os.IsNotExist(err) {
+			t.Errorf("%s shim not created", shimLabel)
+		}
+
+		if !strings.Contains(string(shimContent), shimCall) {
+			t.Errorf("%s shim does not contain expected call (%s not in %s)", shimLabel, shimCall, shimContent)
+		}
+	}
 }

--- a/commands_test.go
+++ b/commands_test.go
@@ -14,7 +14,7 @@ func TestWriteShim(t *testing.T) {
 
 	os.Mkdir(state.GetStatePath("shims"), 0775)
 	testShimPath := state.GetStatePath("shims", "testshim")
-	e := writeShim(testShimPath)
+	e := writeShim(testShimPath, "testcommand")
 
 	shimContent, _ := ioutil.ReadFile(testShimPath)
 
@@ -22,7 +22,7 @@ func TestWriteShim(t *testing.T) {
 		t.Errorf("Errored while writing shim")
 	}
 
-	if !strings.Contains(string(shimContent), "$(v python which --raw) $@") {
+	if !strings.Contains(string(shimContent), "testcommand") {
 		t.Errorf("Expected shim to contain pass-through via 'which', got %s", shimContent)
 	}
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,11 @@
+# Python support
+
+Managing Python versions is supported via `v python <command>`, see `v help` for a breakdown of what's available.
+
+## Shims
+
+Shims are configured in `python/shims.go`.
+
+## Available versions
+
+Versions are pulled from [Python's ftp repository](https://www.python.org/ftp/python/) as gzipped tarballs. Any version available where is available for installation via `v python install`.

--- a/python/shims.go
+++ b/python/shims.go
@@ -1,0 +1,12 @@
+package python
+
+var pythonShimCall = "$(v python which --raw) $@"
+
+var pipShimCall = "$(v python which --raw) -m pip $@"
+
+var Shims = map[string]string{
+	"python":  pythonShimCall,
+	"python3": pythonShimCall,
+	"pip":     pipShimCall,
+	"pip3":    pipShimCall,
+}


### PR DESCRIPTION
# Description

This reorganizes the shim logic so that Python shims are an implementation detail of the `python` module and are exposed as `python.Shims` to the rest of the application.

Shims are made more configurable as well through a mapping of label/name to "shim call", which is just inline shell calling `v` or other commands to pass the command through.