### PR TITLE
refactor(python): simplify python install

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os"
 	"slices"
 	"strings"
 	logger "v/logger"
@@ -47,6 +48,12 @@ func (c *CLI) ListNamespaces() []string {
 // Executes one of the registered commands if any match the provided
 // user arguments.
 func (c CLI) Run(args []string, currentState state.State) error {
+	flags := collectFlags(args)
+
+	if flags.Verbose {
+		logger.DebugLogger.SetOutput(os.Stdout)
+	}
+
 	if len(args) == 0 {
 		c.Help()
 		return nil
@@ -58,8 +65,6 @@ func (c CLI) Run(args []string, currentState state.State) error {
 		c.Help()
 		return nil
 	}
-
-	flags := collectFlags(args)
 
 	namespace, isNamespace := c.Namespaces[action]
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,10 +1,12 @@
 package logger
 
 import (
+	"io/ioutil"
 	"log"
 	"os"
 )
 
 var (
-	InfoLogger = log.New(os.Stdout, "", 0)
+	InfoLogger  = log.New(os.Stdout, "", 0)
+	DebugLogger = log.New(ioutil.Discard, "", 0)
 )

--- a/python/commands.go
+++ b/python/commands.go
@@ -9,7 +9,7 @@ import (
 )
 
 func uninstallPython(args []string, flags cli.Flags, currentState state.State) error {
-	runtimePath := state.GetStatePath("runtimes", "py-"+args[1])
+	runtimePath := state.GetStatePath("runtimes", "python", args[1])
 	err := os.RemoveAll(runtimePath)
 	return err
 }
@@ -79,7 +79,7 @@ func which(args []string, flags cli.Flags, currentState state.State) error {
 		printedPath = sysPath + " (system)"
 	} else if isInstalled {
 		tag := VersionStringToStruct(selectedVersion.Version)
-		printedPath = state.GetStatePath("runtimes", "py-"+selectedVersion.Version, "bin", "python"+tag.MajorMinor())
+		printedPath = state.GetStatePath("runtimes", "python", selectedVersion.Version, "bin", "python"+tag.MajorMinor())
 	} else {
 		logger.InfoLogger.Printf("The desired version (%s) is not installed.\n", selectedVersion.Version)
 		return nil

--- a/python/commands.go
+++ b/python/commands.go
@@ -17,7 +17,7 @@ func uninstallPython(args []string, flags cli.Flags, currentState state.State) e
 func installPython(args []string, flags cli.Flags, currentState state.State) error {
 	version := args[1]
 
-	return InstallPythonDistribution(version, flags.NoCache, flags.Verbose)
+	return InstallPythonDistribution(version, flags.NoCache)
 }
 
 func use(args []string, flags cli.Flags, currentState state.State) error {
@@ -38,7 +38,7 @@ func use(args []string, flags cli.Flags, currentState state.State) error {
 
 	if !found {
 		logger.InfoLogger.Println("Version not installed. Installing it first.")
-		InstallPythonDistribution(version, flags.NoCache, flags.Verbose)
+		InstallPythonDistribution(version, flags.NoCache)
 	}
 
 	state.WriteState(version)

--- a/python/commands_test.go
+++ b/python/commands_test.go
@@ -14,7 +14,7 @@ import (
 func TestListVersionOutputsNoticeIfNoVersionsInstalled(t *testing.T) {
 	defer testutils.SetupAndCleanupEnvironment(t)()
 
-	os.Mkdir(state.GetStatePath("runtimes"), 0750)
+	os.MkdirAll(state.GetStatePath("runtimes", "python"), 0750)
 	var out bytes.Buffer
 
 	logger.InfoLogger.SetOutput(&out)
@@ -31,7 +31,7 @@ func TestListVersionOutputsNoticeIfNoVersionsInstalled(t *testing.T) {
 func TestListVersionOutputsVersionsInstalled(t *testing.T) {
 	defer testutils.SetupAndCleanupEnvironment(t)()
 
-	os.MkdirAll(state.GetStatePath("runtimes", "py-1.2.3"), 0750)
+	os.MkdirAll(state.GetStatePath("runtimes", "python", "1.2.3"), 0750)
 	var out bytes.Buffer
 
 	logger.InfoLogger.SetOutput(&out)
@@ -89,11 +89,11 @@ func TestWhichOutputsVersionSelectedIfInstalled(t *testing.T) {
 	logger.InfoLogger.SetOutput(&out)
 	defer logger.InfoLogger.SetOutput(os.Stdout)
 
-	os.MkdirAll(state.GetStatePath("runtimes", "py-1.2.3"), 0750)
+	os.MkdirAll(state.GetStatePath("runtimes", "python", "1.2.3"), 0750)
 	which([]string{}, cli.Flags{}, state.State{GlobalVersion: "1.2.3"})
 
 	captured := strings.TrimSpace(out.String())
-	expected := state.GetStatePath("runtimes", "py-1.2.3", "bin", "python1.2")
+	expected := state.GetStatePath("runtimes", "python", "1.2.3", "bin", "python1.2")
 	if !strings.Contains(captured, expected) {
 		t.Errorf("Unexpected message: %s, not %s", captured, expected)
 	}
@@ -124,11 +124,11 @@ func TestWhichOutputsVersionWithoutPrefixesIfRawOutput(t *testing.T) {
 	logger.InfoLogger.SetOutput(&out)
 	defer logger.InfoLogger.SetOutput(os.Stdout)
 
-	os.MkdirAll(state.GetStatePath("runtimes", "py-1.2.3"), 0750)
+	os.MkdirAll(state.GetStatePath("runtimes", "python", "1.2.3"), 0750)
 	which([]string{}, cli.Flags{RawOutput: true}, state.State{GlobalVersion: "1.2.3"})
 
 	captured := strings.TrimSpace(out.String())
-	expected := state.GetStatePath("runtimes", "py-1.2.3", "bin", "python1.2")
+	expected := state.GetStatePath("runtimes", "python", "1.2.3", "bin", "python1.2")
 	if captured != expected {
 		t.Errorf("Unexpected message: %s, not %s", captured, expected)
 	}

--- a/python/install.go
+++ b/python/install.go
@@ -107,7 +107,11 @@ func buildFromSource(pkgMeta PackageMetadata, verbose bool) (PackageMetadata, er
 
 	logger.InfoLogger.Println("Configuring installer")
 
-	targetDirectory := state.GetStatePath("runtimes", "py-"+pkgMeta.Version)
+	if _, err := os.Stat(state.GetStatePath("runtimes", "python")); os.IsNotExist(err) {
+		os.Mkdir(state.GetStatePath("runtimes", "python"), 0775)
+	}
+
+	targetDirectory := state.GetStatePath("runtimes", "python", pkgMeta.Version)
 
 	_, configureErr := exec.RunCommand([]string{"./configure", "--prefix=" + targetDirectory, "--enable-optimizations"}, unzippedRoot, !verbose)
 

--- a/python/version.go
+++ b/python/version.go
@@ -30,7 +30,7 @@ type SelectedVersion struct {
 }
 
 func ListInstalledVersions() ([]string, error) {
-	runtimesDir := state.GetStatePath("runtimes")
+	runtimesDir := state.GetStatePath("runtimes", "python")
 	entries, err := os.ReadDir(runtimesDir)
 
 	if err != nil {
@@ -40,7 +40,7 @@ func ListInstalledVersions() ([]string, error) {
 	installedVersions := []string{}
 
 	for _, d := range entries {
-		installedVersions = append(installedVersions, strings.TrimPrefix(d.Name(), "py-"))
+		installedVersions = append(installedVersions, d.Name())
 	}
 
 	return installedVersions, nil

--- a/python/version.go
+++ b/python/version.go
@@ -100,7 +100,7 @@ func DetermineSelectedPythonVersion(currentState state.State) (SelectedVersion, 
 // DetermineSystemPython returns the unshimmed Python version and path.
 // It assumes that /bin/python is where system Python lives.
 func DetermineSystemPython() (string, string) {
-	versionOut, _ := exec.RunCommand([]string{"/bin/python", "--version"}, state.GetStatePath(), true)
+	versionOut, _ := exec.RunCommand([]string{"/bin/python", "--version"}, state.GetStatePath())
 	detectedVersion, _ := strings.CutPrefix(versionOut, "Python")
 	return strings.TrimSpace(detectedVersion), "/bin/python"
 }

--- a/python/version_test.go
+++ b/python/version_test.go
@@ -127,7 +127,7 @@ func TestListInstalledVersion(t *testing.T) {
 
 	os.Mkdir(state.GetStatePath("runtimes"), 0750)
 	for _, version := range versions {
-		os.Mkdir(state.GetStatePath("runtimes", "py-"+version), 0750)
+		os.MkdirAll(state.GetStatePath("runtimes", "python", version), 0750)
 	}
 
 	installedVersions, _ := ListInstalledVersions()
@@ -140,7 +140,7 @@ func TestListInstalledVersion(t *testing.T) {
 func TestListInstalledVersionNoVersionsInstalled(t *testing.T) {
 	defer testutils.SetupAndCleanupEnvironment(t)()
 
-	os.Mkdir(state.GetStatePath("runtimes"), 0750)
+	os.MkdirAll(state.GetStatePath("runtimes", "python"), 0750)
 
 	installedVersions, _ := ListInstalledVersions()
 

--- a/state/state.go
+++ b/state/state.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"strings"
 )
 
 // Persistent state used by the CLI to track runtime information
@@ -46,12 +45,12 @@ func WriteState(version string) {
 }
 
 func GetAvailableVersions() []string {
-	entries, _ := os.ReadDir(GetStatePath("runtimes"))
+	entries, _ := os.ReadDir(GetStatePath("runtimes", "python"))
 
 	versions := []string{}
 
 	for _, d := range entries {
-		versions = append(versions, strings.TrimPrefix(d.Name(), "py-"))
+		versions = append(versions, d.Name())
 	}
 
 	return versions


### PR DESCRIPTION
# Description

This simplifies the distribution install process a tad by removing `--verbose` flag drilling and nits like `http.Client` structs that were not leveraged.

This also removes some runtime path handling by installing distributions to `runtimes/python/<version>` - this allows easier expansion into other runtimes (i.e. `runtimes/node/<version>` becomes easier to achieve).