### PR TITLE
fix(python): handle cases where the python runtime dir does not exist

### DIFF
--- a/python/version.go
+++ b/python/version.go
@@ -30,8 +30,16 @@ type SelectedVersion struct {
 }
 
 func ListInstalledVersions() ([]string, error) {
+	if ensureErr := state.EnsureStatePath("runtimes"); ensureErr != nil {
+		return []string{}, ensureErr
+	}
+
 	runtimesDir := state.GetStatePath("runtimes", "python")
 	entries, err := os.ReadDir(runtimesDir)
+
+	if os.IsNotExist(err) {
+		return []string{}, nil
+	}
 
 	if err != nil {
 		return []string{}, err

--- a/python/version_test.go
+++ b/python/version_test.go
@@ -149,6 +149,18 @@ func TestListInstalledVersionNoVersionsInstalled(t *testing.T) {
 	}
 }
 
+func TestListInstalledVersionNoVersionsInstalledNoPythonDir(t *testing.T) {
+	defer testutils.SetupAndCleanupEnvironment(t)()
+
+	os.MkdirAll(state.GetStatePath("runtimes"), 0750)
+
+	installedVersions, _ := ListInstalledVersions()
+
+	if len(installedVersions) != 0 {
+		t.Errorf("Expected 0 elements, got %d (%s).", len(installedVersions), installedVersions)
+	}
+}
+
 func TestListInstalledVersionNoRuntimesDir(t *testing.T) {
 	defer testutils.SetupAndCleanupEnvironment(t)()
 

--- a/state/state.go
+++ b/state/state.go
@@ -27,6 +27,14 @@ func GetStatePath(pathSegments ...string) string {
 	return path.Join(allSegments...)
 }
 
+func EnsureStatePath(pathSegments ...string) error {
+	path := GetStatePath(pathSegments...)
+
+	_, err := os.Stat(path)
+
+	return err
+}
+
 func ReadState() State {
 	c, _ := ioutil.ReadFile(GetStatePath("state.json"))
 


### PR DESCRIPTION
# Description

When `runtimes/python` does not exist, no versions have been installed yet (i.e. fresh `v init`). In this case, we should report "no versions installed" instead of an unhandled error.